### PR TITLE
Add missing accessors to LazyModule

### DIFF
--- a/diplomacy/src/diplomacy/bundlebridge/BundleBridgeEphemeralNode.scala
+++ b/diplomacy/src/diplomacy/bundlebridge/BundleBridgeEphemeralNode.scala
@@ -2,9 +2,10 @@ package org.chipsalliance.diplomacy.bundlebridge
 
 import chisel3.Data
 
+import org.chipsalliance.diplomacy.ValName
 import org.chipsalliance.diplomacy.nodes.EphemeralNode
 
 case class BundleBridgeEphemeralNode[T <: Data](
 )(
-  implicit valName: sourcecode.Name)
+  implicit valName: ValName)
     extends EphemeralNode(new BundleBridgeImp[T])()

--- a/diplomacy/src/diplomacy/bundlebridge/BundleBridgeIdentityNode.scala
+++ b/diplomacy/src/diplomacy/bundlebridge/BundleBridgeIdentityNode.scala
@@ -1,9 +1,11 @@
 package org.chipsalliance.diplomacy.bundlebridge
 
 import chisel3.Data
+
+import org.chipsalliance.diplomacy.ValName
 import org.chipsalliance.diplomacy.nodes.IdentityNode
 
 case class BundleBridgeIdentityNode[T <: Data](
 )(
-  implicit valName: sourcecode.Name)
+  implicit valName: ValName)
     extends IdentityNode(new BundleBridgeImp[T])()

--- a/diplomacy/src/diplomacy/bundlebridge/BundleBridgeNexusNode.scala
+++ b/diplomacy/src/diplomacy/bundlebridge/BundleBridgeNexusNode.scala
@@ -1,6 +1,8 @@
 package org.chipsalliance.diplomacy.bundlebridge
 
 import chisel3.Data
+
+import org.chipsalliance.diplomacy.ValName
 import org.chipsalliance.diplomacy.nodes.NexusNode
 
 case class BundleBridgeNexusNode[T <: Data](
@@ -8,7 +10,7 @@ case class BundleBridgeNexusNode[T <: Data](
   inputRequiresOutput: Boolean = false
 ) // when false, connecting a source does not mandate connecting a sink
 (
-  implicit valName:    sourcecode.Name)
+  implicit valName:    ValName)
     extends NexusNode(new BundleBridgeImp[T])(
       dFn = seq => seq.headOption.getOrElse(BundleBridgeParams(default)),
       uFn = seq => seq.headOption.getOrElse(BundleBridgeParams(None)),

--- a/diplomacy/src/diplomacy/bundlebridge/BundleBridgeSink.scala
+++ b/diplomacy/src/diplomacy/bundlebridge/BundleBridgeSink.scala
@@ -3,12 +3,14 @@ package org.chipsalliance.diplomacy.bundlebridge
 import chisel3.{chiselTypeOf, ActualDirection, Data, IO, Output}
 import chisel3.reflect.DataMirror
 import chisel3.reflect.DataMirror.internal.chiselTypeClone
+
+import org.chipsalliance.diplomacy.ValName
 import org.chipsalliance.diplomacy.nodes.SinkNode
 
 case class BundleBridgeSink[T <: Data](
   genOpt:           Option[() => T] = None
 )(
-  implicit valName: sourcecode.Name)
+  implicit valName: ValName)
     extends SinkNode(new BundleBridgeImp[T])(Seq(BundleBridgeParams(genOpt))) {
   def bundle: T = in(0)._1
 
@@ -18,7 +20,7 @@ case class BundleBridgeSink[T <: Data](
 
   def makeIO(
   )(
-    implicit valName: sourcecode.Name
+    implicit valName: ValName
   ): T = {
     val io: T = IO(
       if (inferOutput) Output(chiselTypeOf(bundle))
@@ -28,13 +30,13 @@ case class BundleBridgeSink[T <: Data](
     io <> bundle
     io
   }
-  def makeIO(name: String): T = makeIO()(sourcecode.Name(name))
+  def makeIO(name: String): T = makeIO()(ValName(name))
 }
 
 object BundleBridgeSink {
   def apply[T <: Data](
   )(
-    implicit valName: sourcecode.Name
+    implicit valName: ValName
   ): BundleBridgeSink[T] = {
     BundleBridgeSink(None)
   }

--- a/diplomacy/src/diplomacy/bundlebridge/BundleBridgeSource.scala
+++ b/diplomacy/src/diplomacy/bundlebridge/BundleBridgeSource.scala
@@ -4,12 +4,14 @@ import chisel3.{chiselTypeOf, ActualDirection, Data, Flipped, IO, Input}
 import chisel3.reflect.DataMirror
 import chisel3.reflect.DataMirror.internal.chiselTypeClone
 import org.chipsalliance.cde.config.Parameters
+
+import org.chipsalliance.diplomacy.ValName
 import org.chipsalliance.diplomacy.nodes.SourceNode
 
 case class BundleBridgeSource[T <: Data](
   genOpt:           Option[() => T] = None
 )(
-  implicit valName: sourcecode.Name)
+  implicit valName: ValName)
     extends SourceNode(new BundleBridgeImp[T])(Seq(BundleBridgeParams(genOpt))) {
   def bundle: T = out(0)._1
 
@@ -19,7 +21,7 @@ case class BundleBridgeSource[T <: Data](
 
   def makeIO(
   )(
-    implicit valName: sourcecode.Name
+    implicit valName: ValName
   ): T = {
     val io: T = IO(
       if (inferInput) Input(chiselTypeOf(bundle))
@@ -29,7 +31,7 @@ case class BundleBridgeSource[T <: Data](
     bundle <> io
     io
   }
-  def makeIO(name: String): T = makeIO()(sourcecode.Name(name))
+  def makeIO(name: String): T = makeIO()(ValName(name))
 
   private var doneSink = false
   def makeSink(
@@ -47,14 +49,14 @@ case class BundleBridgeSource[T <: Data](
 object BundleBridgeSource {
   def apply[T <: Data](
   )(
-    implicit valName: sourcecode.Name
+    implicit valName: ValName
   ): BundleBridgeSource[T] = {
     BundleBridgeSource(None)
   }
   def apply[T <: Data](
     gen:              () => T
   )(
-    implicit valName: sourcecode.Name
+    implicit valName: ValName
   ): BundleBridgeSource[T] = {
     BundleBridgeSource(Some(gen))
   }

--- a/diplomacy/src/diplomacy/bundlebridge/package.scala
+++ b/diplomacy/src/diplomacy/bundlebridge/package.scala
@@ -2,13 +2,15 @@ package org.chipsalliance.diplomacy
 
 import chisel3.{Aggregate, Data, Element}
 import org.chipsalliance.cde.config.Parameters
+
+import org.chipsalliance.diplomacy.ValName
 import org.chipsalliance.diplomacy.lazymodule.LazyModule
 import org.chipsalliance.diplomacy.nodes.{InwardNodeHandle, NodeHandle, OutwardNodeHandle}
 
 package object bundlebridge {
 
   def BundleBridgeNameNode[T <: Data](name: String): BundleBridgeIdentityNode[T] =
-    BundleBridgeIdentityNode[T]()(sourcecode.Name(name))
+    BundleBridgeIdentityNode[T]()(ValName(name))
 
   def BundleBroadcast[T <: Data](
     name:                Option[String] = None,

--- a/diplomacy/src/diplomacy/lazymodule/Clone.scala
+++ b/diplomacy/src/diplomacy/lazymodule/Clone.scala
@@ -1,7 +1,8 @@
 package org.chipsalliance.diplomacy.lazymodule
 
 import chisel3.experimental.SourceInfo
-import org.chipsalliance.diplomacy.sourceLine
+
+import org.chipsalliance.diplomacy.{sourceLine, ValName}
 
 object CloneLazyModule {
 
@@ -18,7 +19,7 @@ object CloneLazyModule {
     bc:               A,
     cloneProto:       B
   )(
-    implicit valName: sourcecode.Name,
+    implicit valName: ValName,
     sourceInfo:       SourceInfo
   ): A = {
     require(

--- a/diplomacy/src/diplomacy/lazymodule/LazyModule.scala
+++ b/diplomacy/src/diplomacy/lazymodule/LazyModule.scala
@@ -4,7 +4,8 @@ package org.chipsalliance.diplomacy.lazymodule
 
 import chisel3.experimental.{ChiselAnnotation, CloneModuleAsRecord, SourceInfo, UnlocatableSourceInfo}
 import org.chipsalliance.cde.config.Parameters
-import org.chipsalliance.diplomacy.sourceLine
+
+import org.chipsalliance.diplomacy.{sourceLine, ValName}
 import org.chipsalliance.diplomacy.nodes.{BaseNode, Dangle, RenderedEdge}
 
 import scala.collection.immutable.SortedMap
@@ -260,6 +261,12 @@ abstract class LazyModule(
 
   /** Accessor for [[nodes]]. */
   def getNodes: List[BaseNode] = nodes
+
+  /** Accessor for [[info]]. */
+  def getInfo: SourceInfo = info
+
+  /** Accessor for [[parent]]. */
+  def getParent: Option[LazyModule] = parent
 }
 
 object LazyModule {
@@ -269,6 +276,9 @@ object LazyModule {
     * Each call to [[LazyScope.apply]] or [[LazyModule.apply]] will push that item onto the current scope.
     */
   protected[diplomacy] var scope: Option[LazyModule] = None
+
+  /** Accessor for [[scope]]. */
+  def getScope: Option[LazyModule] = scope
 
   /** Global index of [[LazyModule]]. Note that there is no zeroth module. */
   private var index = 0
@@ -288,7 +298,7 @@ object LazyModule {
   def apply[T <: LazyModule](
     bc:               T
   )(
-    implicit valName: sourcecode.Name,
+    implicit valName: ValName,
     sourceInfo:       SourceInfo
   ): T = {
     // Make sure the user puts [[LazyModule]] around modules in the correct order.

--- a/diplomacy/src/diplomacy/lazymodule/LazyScope.scala
+++ b/diplomacy/src/diplomacy/lazymodule/LazyScope.scala
@@ -2,6 +2,8 @@ package org.chipsalliance.diplomacy.lazymodule
 
 import org.chipsalliance.cde.config.Parameters
 
+import org.chipsalliance.diplomacy.ValName
+
 /** Allows dynamic creation of [[Module]] hierarchy and "shoving" logic into a [[LazyModule]]. */
 trait LazyScope {
   this: LazyModule =>
@@ -48,7 +50,7 @@ object LazyScope {
   def apply[T](
     body:             => T
   )(
-    implicit valName: sourcecode.Name,
+    implicit valName: ValName,
     p:                Parameters
   ): T = {
     apply(valName.value, "SimpleLazyModule", None)(body)(p)

--- a/diplomacy/src/diplomacy/nodes/AdapterNode.scala
+++ b/diplomacy/src/diplomacy/nodes/AdapterNode.scala
@@ -2,6 +2,8 @@ package org.chipsalliance.diplomacy.nodes
 
 import chisel3.Data
 
+import org.chipsalliance.diplomacy.ValName
+
 /** [[MixedAdapterNode]] is used to transform between different diplomacy protocols ([[NodeImp]]), without changing the
   * number of edges passing through it.
   *
@@ -21,7 +23,7 @@ class MixedAdapterNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
 )(dFn:              DI => DO,
   uFn:              UO => UI
 )(
-  implicit valName: sourcecode.Name)
+  implicit valName: ValName)
     extends MixedNode(inner, outer) {
   override def description                                 = "adapter"
   protected[diplomacy] override def flexibleArityDirection = true
@@ -101,5 +103,5 @@ class AdapterNode[D, U, EO, EI, B <: Data](
 )(dFn:              D => D,
   uFn:              U => U
 )(
-  implicit valName: sourcecode.Name)
+  implicit valName: ValName)
     extends MixedAdapterNode[D, U, EI, B, D, U, EO, B](imp, imp)(dFn, uFn)

--- a/diplomacy/src/diplomacy/nodes/BaseNode.scala
+++ b/diplomacy/src/diplomacy/nodes/BaseNode.scala
@@ -3,6 +3,8 @@ package org.chipsalliance.diplomacy.nodes
 import chisel3.Data
 import chisel3.experimental.SourceInfo
 import org.chipsalliance.cde.config.Parameters
+
+import org.chipsalliance.diplomacy.ValName
 import org.chipsalliance.diplomacy.lazymodule.LazyModule
 import org.chipsalliance.diplomacy.sourceLine
 
@@ -15,7 +17,7 @@ import scala.collection.mutable.ListBuffer
   *   [[ValName]] of this node, used by naming inference.
   */
 abstract class BaseNode(
-  implicit val valName: sourcecode.Name) {
+  implicit val valName: ValName) {
 
   /** All subclasses of [[BaseNode]]s are expected to be instantiated only within [[LazyModule]]s.
     *

--- a/diplomacy/src/diplomacy/nodes/CustomNode.scala
+++ b/diplomacy/src/diplomacy/nodes/CustomNode.scala
@@ -2,12 +2,14 @@ package org.chipsalliance.diplomacy.nodes
 
 import chisel3.Data
 
+import org.chipsalliance.diplomacy.ValName
+
 /** A [[MixedNode]] that may be extended with custom behavior. */
 abstract class MixedCustomNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
   inner:            InwardNodeImp[DI, UI, EI, BI],
   outer:            OutwardNodeImp[DO, UO, EO, BO]
 )(
-  implicit valName: sourcecode.Name)
+  implicit valName: ValName)
     extends MixedNode(inner, outer) {
   override def description = "custom"
   def resolveStar(iKnown: Int, oKnown: Int, iStars: Int, oStars: Int): (Int, Int)
@@ -22,5 +24,5 @@ abstract class MixedCustomNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
 abstract class CustomNode[D, U, EO, EI, B <: Data](
   imp:              NodeImp[D, U, EO, EI, B]
 )(
-  implicit valName: sourcecode.Name)
+  implicit valName: ValName)
     extends MixedCustomNode(imp, imp)

--- a/diplomacy/src/diplomacy/nodes/EphemeralNode.scala
+++ b/diplomacy/src/diplomacy/nodes/EphemeralNode.scala
@@ -2,6 +2,8 @@ package org.chipsalliance.diplomacy.nodes
 
 import chisel3.Data
 
+import org.chipsalliance.diplomacy.ValName
+
 /** [[EphemeralNode]]s are used as temporary connectivity placeholders, but disappear from the final node graph. An
   * ephemeral node provides a mechanism to directly connect two nodes to each other where neither node knows about the
   * other, but both know about an ephemeral node they can use to facilitate the connection.
@@ -10,7 +12,7 @@ class EphemeralNode[D, U, EO, EI, B <: Data](
   imp:              NodeImp[D, U, EO, EI, B]
 )(
 )(
-  implicit valName: sourcecode.Name)
+  implicit valName: ValName)
     extends AdapterNode(imp)({ s => s }, { s => s }) {
   override def description           = "ephemeral"
   override final def circuitIdentity = true

--- a/diplomacy/src/diplomacy/nodes/IdentityNode.scala
+++ b/diplomacy/src/diplomacy/nodes/IdentityNode.scala
@@ -2,6 +2,8 @@ package org.chipsalliance.diplomacy.nodes
 
 import chisel3.Data
 
+import org.chipsalliance.diplomacy.ValName
+
 /** A node which does not modify the parameters nor the protocol for edges that pass through it.
   *
   * During hardware generation, [[IdentityNode]]s automatically connect their inputs to outputs.
@@ -10,7 +12,7 @@ class IdentityNode[D, U, EO, EI, B <: Data](
   imp:              NodeImp[D, U, EO, EI, B]
 )(
 )(
-  implicit valName: sourcecode.Name)
+  implicit valName: ValName)
     extends AdapterNode(imp)({ s => s }, { s => s }) {
   override def description           = "identity"
   override final def circuitIdentity = true

--- a/diplomacy/src/diplomacy/nodes/JunctionNode.scala
+++ b/diplomacy/src/diplomacy/nodes/JunctionNode.scala
@@ -2,6 +2,8 @@ package org.chipsalliance.diplomacy.nodes
 
 import chisel3.Data
 
+import org.chipsalliance.diplomacy.ValName
+
 /** A JunctionNode creates multiple parallel arbiters.
   *
   * @example
@@ -36,7 +38,7 @@ class MixedJunctionNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
 )(dFn:              Seq[DI] => Seq[DO],
   uFn:              Seq[UO] => Seq[UI]
 )(
-  implicit valName: sourcecode.Name)
+  implicit valName: ValName)
     extends MixedNode(inner, outer) {
   protected[diplomacy] var multiplicity = 0
 
@@ -88,5 +90,5 @@ class JunctionNode[D, U, EO, EI, B <: Data](
 )(dFn:              Seq[D] => Seq[D],
   uFn:              Seq[U] => Seq[U]
 )(
-  implicit valName: sourcecode.Name)
+  implicit valName: ValName)
     extends MixedJunctionNode[D, U, EI, B, D, U, EO, B](imp, imp)(dFn, uFn)

--- a/diplomacy/src/diplomacy/nodes/MixedNode.scala
+++ b/diplomacy/src/diplomacy/nodes/MixedNode.scala
@@ -3,6 +3,8 @@ package org.chipsalliance.diplomacy.nodes
 import chisel3.{Data, DontCare, Wire}
 import chisel3.experimental.SourceInfo
 import org.chipsalliance.cde.config.{Field, Parameters}
+
+import org.chipsalliance.diplomacy.ValName
 import org.chipsalliance.diplomacy.lazymodule.LazyModuleImp
 import org.chipsalliance.diplomacy.sourceLine
 
@@ -163,7 +165,7 @@ protected[diplomacy] abstract class MixedNode[DI, UI, EI, BI <: Data, DO, UO, EO
   val inner:        InwardNodeImp[DI, UI, EI, BI],
   val outer:        OutwardNodeImp[DO, UO, EO, BO]
 )(
-  implicit valName: sourcecode.Name)
+  implicit valName: ValName)
     extends BaseNode
     with NodeHandle[DI, UI, EI, BI, DO, UO, EO, BO]
     with InwardNode[DI, UI, BI]

--- a/diplomacy/src/diplomacy/nodes/NexusNode.scala
+++ b/diplomacy/src/diplomacy/nodes/NexusNode.scala
@@ -2,6 +2,8 @@ package org.chipsalliance.diplomacy.nodes
 
 import chisel3.Data
 
+import org.chipsalliance.diplomacy.ValName
+
 /** [[MixedNexusNode]] is used when the number of nodes connecting from either side is unknown (e.g. a Crossbar which
   * also is a protocol adapter).
   *
@@ -27,7 +29,7 @@ class MixedNexusNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
   inputRequiresOutput: Boolean = true,
   outputRequiresInput: Boolean = true
 )(
-  implicit valName:    sourcecode.Name)
+  implicit valName:    ValName)
     extends MixedNode(inner, outer) {
   override def description = "nexus"
   protected[diplomacy] def resolveStar(iKnown: Int, oKnown: Int, iStars: Int, oStars: Int): (Int, Int) = {
@@ -76,5 +78,5 @@ class NexusNode[D, U, EO, EI, B <: Data](
   inputRequiresOutput: Boolean = true,
   outputRequiresInput: Boolean = true
 )(
-  implicit valName:    sourcecode.Name)
+  implicit valName:    ValName)
     extends MixedNexusNode[D, U, EI, B, D, U, EO, B](imp, imp)(dFn, uFn, inputRequiresOutput, outputRequiresInput)

--- a/diplomacy/src/diplomacy/nodes/SinkNode.scala
+++ b/diplomacy/src/diplomacy/nodes/SinkNode.scala
@@ -2,6 +2,8 @@ package org.chipsalliance.diplomacy.nodes
 
 import chisel3.{Data, IO}
 
+import org.chipsalliance.diplomacy.ValName
+
 /** A node which represents a node in the graph which has only inward edges, no outward edges.
   *
   * A [[SinkNode]] cannot appear cannot appear right of a `:=`, `:*=`, `:=*`, or `:*=*`
@@ -12,7 +14,7 @@ class SinkNode[D, U, EO, EI, B <: Data](
   imp:              NodeImp[D, U, EO, EI, B]
 )(pi:               Seq[U]
 )(
-  implicit valName: sourcecode.Name)
+  implicit valName: ValName)
     extends MixedNode(imp, imp) {
   override def description = "sink"
   protected[diplomacy] def resolveStar(iKnown: Int, oKnown: Int, iStars: Int, oStars: Int): (Int, Int) = {
@@ -68,7 +70,7 @@ class SinkNode[D, U, EO, EI, B <: Data](
 
   def makeIOs(
   )(
-    implicit valName: sourcecode.Name
+    implicit valName: ValName
   ): HeterogeneousBag[B] = {
     val bundles = this.in.map(_._1)
     val ios     = IO(new HeterogeneousBag(bundles))

--- a/diplomacy/src/diplomacy/nodes/SourceNode.scala
+++ b/diplomacy/src/diplomacy/nodes/SourceNode.scala
@@ -2,6 +2,8 @@ package org.chipsalliance.diplomacy.nodes
 
 import chisel3.{Data, Flipped, IO}
 
+import org.chipsalliance.diplomacy.ValName
+
 /** A node which represents a node in the graph which only has outward edges and no inward edges.
   *
   * A [[SourceNode]] cannot appear left of a `:=`, `:*=`, `:=*, or `:*=*` There are no Mixed [[SourceNode]]s, There are
@@ -11,7 +13,7 @@ class SourceNode[D, U, EO, EI, B <: Data](
   imp:              NodeImp[D, U, EO, EI, B]
 )(po:               Seq[D]
 )(
-  implicit valName: sourcecode.Name)
+  implicit valName: ValName)
     extends MixedNode(imp, imp) {
 
   override def description = "source"
@@ -68,7 +70,7 @@ class SourceNode[D, U, EO, EI, B <: Data](
 
   def makeIOs(
   )(
-    implicit valName: sourcecode.Name
+    implicit valName: ValName
   ): HeterogeneousBag[B] = {
     val bundles = this.out.map(_._1)
     val ios     = IO(Flipped(new HeterogeneousBag(bundles)))

--- a/diplomacy/src/diplomacy/package.scala
+++ b/diplomacy/src/diplomacy/package.scala
@@ -164,6 +164,10 @@ import scala.language.implicitConversions
   */
 package object diplomacy {
 
+  type ValName = sourcecode.Name
+
+  def ValName(value: String) = sourcecode.Name(value)
+
   private[diplomacy] def sourceLine(sourceInfo: SourceInfo, prefix: String = " (", suffix: String = ")") =
     sourceInfo match {
       case SourceLine(filename, line, col) => s"$prefix$filename:$line:$col$suffix"


### PR DESCRIPTION
Adds missing accessors for private values in LazyModule. Replaces sourcecode.Name calls with own ValName type for consistency with rocket-chip.